### PR TITLE
basic CLI support

### DIFF
--- a/bin/hbase-sql
+++ b/bin/hbase-sql
@@ -18,12 +18,12 @@
 #
 
 #
-# Shell script for starting the Spark SQL CLI
+# Shell script for starting the Spark SQL for HBase CLI
 
 # Enter posix mode for bash
 set -o posix
 
-CLASS="org.apache.spark.sql.hbase.HBaseSQLDriver
+CLASS="org.apache.spark.sql.hbase.HBaseSQLCLIDriver"
 
 # Figure out where Spark is installed
 FWDIR="$(cd "`dirname "$0"`"/..; pwd)"
@@ -31,7 +31,7 @@ FWDIR="$(cd "`dirname "$0"`"/..; pwd)"
 function usage {
   echo "Usage: ./bin/hbase-sql [options] [cli option]"
   pattern="usage"
-  pattern+="\|Spark assembly has been built with Hive"
+  pattern+="\|Spark assembly has been built with hbase"
   pattern+="\|NOTE: SPARK_PREPEND_CLASSES is set"
   pattern+="\|Spark Command: "
   pattern+="\|--help"

--- a/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLCliDriver.scala
+++ b/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLCliDriver.scala
@@ -14,12 +14,114 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.spark.sql.hbase
+
+import java.io.File
+
+import jline.{ConsoleReader, History}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SchemaRDD
 
 /**
  * HBaseSQLCliDriver
  *
  */
-class HBaseSQLCliDriver {
+object HBaseSQLCLIDriver {
+  private val prompt = "spark-hbaseql"
+  private val continuedPrompt = "".padTo(prompt.length, ' ')
+  private val conf = new SparkConf()
+  private val sc = new SparkContext(conf)
+  private val hbaseCtx = new HBaseSQLContext(sc)
+
+  def main(args: Array[String]) {
+
+    val reader = new ConsoleReader()
+    reader.setBellEnabled(false)
+
+    val historyDirectory = System.getProperty("user.home")
+
+    try {
+      if (new File(historyDirectory).exists()) {
+        val historyFile = historyDirectory + File.separator + ".hbaseqlhistory"
+        reader.setHistory(new History(new File(historyFile)))
+      } else {
+        System.err.println("WARNING: Directory for hbaseql history file: " + historyDirectory +
+          " does not exist.   History will not be available during this session.")
+      }
+    } catch {
+      case e: Exception =>
+        System.err.println("WARNING: Encountered an error while trying to initialize hbaseql's " +
+          "history file.  History will not be available during this session.")
+        System.err.println(e.getMessage)
+    }
+
+    println("Welcome to hbaseql CLI")
+    var prefix = ""
+
+    def promptPrefix = s"$prompt"
+    var currentPrompt = promptPrefix
+    var line = reader.readLine(currentPrompt + "> ")
+    var ret = 0
+
+    while (line != null) {
+      if (prefix.nonEmpty) {
+        prefix += '\n'
+      }
+
+      if (line.trim().endsWith(";") && !line.trim().endsWith("\\;")) {
+        line = prefix + line
+        ret = processLine(line, true)
+        prefix = ""
+        currentPrompt = promptPrefix
+      } else {
+        prefix = prefix + line
+        currentPrompt = continuedPrompt
+      }
+
+      line = reader.readLine(currentPrompt + "> ")
+    }
+
+    System.exit(0)
+  }
+
+  private def processLine(line: String, allowInterrupting: Boolean): Int = {
+    processCmd(line)
+    println(s"processing line: $line")
+    try {
+
+      // Since we are using SqlParser to handle 'select' clause, and it does not handle ';',
+      // just work around to omit the ';'
+      val statement =
+        if (line.trim.toLowerCase.startsWith("select")) line.substring(0, line.length - 1)
+        else line
+
+      val start = System.currentTimeMillis()
+      val rdd = hbaseCtx.sql(statement)
+      val end = System.currentTimeMillis()
+      printResult(rdd)
+
+      val timeTaken: Double = (end - start) / 1000.0
+      println(s"Time taken: $timeTaken seconds")
+      0
+    } catch {
+      case e: Exception =>
+        e.printStackTrace()
+        1
+    }
+  }
+
+  private def printResult(result: SchemaRDD) = {
+    println("===================")
+    println("      result")
+    println("===================")
+    result.collect().foreach(println)
+  }
+
+  private def processCmd(line: String) = {
+    val cmd = line.trim.toLowerCase
+    if (cmd.startsWith("quit") || cmd.startsWith("exit"))
+      System.exit(0)
+  }
 
 }


### PR DESCRIPTION
Added a basic CLI for hbase sql, you can start the CLI by ./bin/hbase-sql script.
The DDL and DML used in CLI should end with ";"
To quit CLI, use either "quit;" or "exit;"

please try and feed back to me

@yzhou2001 @xinyunh @bomeng @sboeschhuawei @scwf 
