### PR TITLE
refactor to use HBaseRelation in DROP and ALTER

### DIFF
--- a/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLParser.scala
+++ b/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLParser.scala
@@ -134,17 +134,17 @@ class HBaseSQLParser extends SqlParser {
     }
 
   protected lazy val drop: Parser[LogicalPlan] =
-    DROP ~> TABLE ~> ident <~ opt(";") ^^ {
+    DROP ~> TABLE ~> relation <~ opt(";") ^^ {
       case tableName => DropTablePlan(tableName)
     }
 
   protected lazy val alterDrop: Parser[LogicalPlan] =
-    ALTER ~> TABLE ~> ident ~
+    ALTER ~> TABLE ~> relation ~
       (DROP ~> ident) <~ opt(";") ^^ {
       case tableName ~ colName => AlterDropColPlan(tableName, colName)
     }
   protected lazy val alterAdd: Parser[LogicalPlan] =
-    ALTER ~> TABLE ~> ident ~
+    ALTER ~> TABLE ~> relation ~
       (ADD ~> tableCol) ~
       (MAPPED ~> BY ~> "(" ~> expressions <~ ")") ^^ {
       case tableName ~ tableColumn ~ mappingInfo => {

--- a/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/HBaseStrategies.scala
+++ b/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/HBaseStrategies.scala
@@ -93,13 +93,13 @@ private[hbase] trait HBaseStrategies extends QueryPlanner[SparkPlan] {
         execution.BulkLoadIntoTable(path, table, isLocal, delimiter)(hbaseSQLContext) :: Nil
       case InsertIntoTable(table: HBaseRelation, partition, child, _) =>
         new InsertIntoHBaseTable(table, planLater(child))(hbaseSQLContext) :: Nil
-      case logical.AlterDropColPlan(tableName, colName) =>
+      case logical.AlterDropColPlan(tableName: HBaseRelation, colName) =>
         Seq(AlterDropColCommand(tableName, colName)
           (hbaseSQLContext))
-      case logical.AlterAddColPlan(tableName, colName, colType, colFamily, colQualifier) =>
+      case logical.AlterAddColPlan(tableName: HBaseRelation, colName, colType, colFamily, colQualifier) =>
         Seq(AlterAddColCommand(tableName, colName, colType, colFamily, colQualifier)
           (hbaseSQLContext))
-      case logical.DropTablePlan(tableName) =>
+      case logical.DropTablePlan(tableName: HBaseRelation) =>
         Seq(DropHbaseTableCommand(tableName)
           (hbaseSQLContext))
       case _ => Nil

--- a/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/execution/hbaseCommands.scala
+++ b/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/execution/hbaseCommands.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hbase.execution
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.{Command, LeafNode}
-import org.apache.spark.sql.hbase.{NonKeyColumn, KeyColumn, HBaseSQLContext}
+import org.apache.spark.sql.hbase.{HBaseRelation, NonKeyColumn, KeyColumn, HBaseSQLContext}
 
 case class CreateHBaseTableCommand(
                                     tableName: String,
@@ -61,19 +61,19 @@ case class CreateHBaseTableCommand(
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class AlterDropColCommand(tableName: String, columnName: String)
+case class AlterDropColCommand(tableName: HBaseRelation, columnName: String)
                               (@transient context: HBaseSQLContext)
   extends LeafNode with Command {
 
   override protected[sql] lazy val sideEffectResult = {
-    context.catalog.alterTableDropNonKey(tableName, columnName)
+    context.catalog.alterTableDropNonKey(tableName.tableName, columnName)
     Seq.empty[Row]
   }
 
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class AlterAddColCommand(tableName: String,
+case class AlterAddColCommand(tableName: HBaseRelation,
                               colName: String,
                               colType: String,
                               colFamily: String,
@@ -82,7 +82,7 @@ case class AlterAddColCommand(tableName: String,
   extends LeafNode with Command {
 
   override protected[sql] lazy val sideEffectResult = {
-    context.catalog.alterTableAddNonKey(tableName,
+    context.catalog.alterTableAddNonKey(tableName.tableName,
       NonKeyColumn(
         colName, context.catalog.getDataType(colType), colFamily, colQualifier)
     )
@@ -92,12 +92,12 @@ case class AlterAddColCommand(tableName: String,
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class DropHbaseTableCommand(tableName: String)
+case class DropHbaseTableCommand(tableName: HBaseRelation)
                                 (@transient context: HBaseSQLContext)
   extends LeafNode with Command {
 
   override protected[sql] lazy val sideEffectResult = {
-    context.catalog.deleteTable(tableName)
+    context.catalog.deleteTable(tableName.tableName)
     Seq.empty[Row]
   }
 

--- a/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/logical/hbaseOperators.scala
+++ b/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/logical/hbaseOperators.scala
@@ -25,11 +25,11 @@ case class CreateHBaseTablePlan(tableName: String,
                                 keyCols: Seq[(String, String)],
                                 nonKeyCols: Seq[(String, String, String, String)]) extends Command
 
-case class DropTablePlan(tableName: String) extends Command
+case class DropTablePlan(tableName: LogicalPlan) extends Command
 
-case class AlterDropColPlan(tableName: String, colName: String) extends Command
+case class AlterDropColPlan(tableName: LogicalPlan, colName: String) extends Command
 
-case class AlterAddColPlan(tableName: String,
+case class AlterAddColPlan(tableName: LogicalPlan,
                            colName: String,
                            colType: String,
                            colFamily: String,


### PR DESCRIPTION
I think it is better to use HBaseRelation instead of a plain String, so that parser can validate the relation before executing it.

@xinyunh 
