### PR TITLE
Make HBaseSQLContext and HBaseStrategies more comply to SparkSQL

### DIFF
--- a/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLContext.scala
+++ b/sql/hbase/src/main/scala/org/apache/spark/sql/hbase/HBaseSQLContext.scala
@@ -63,13 +63,14 @@ class HBaseSQLContext(@transient val sc: SparkContext,
     // is compilation problem using super.strategies
     override val strategies: Seq[Strategy] = Seq(
       CommandStrategy(self),
-      HBaseOperations,
+      HBaseCommandStrategy(self),
       TakeOrdered,
-      InMemoryScans,
-      HBaseTableScans,
       HashAggregation,
       LeftSemiJoin,
       HashJoin,
+      InMemoryScans,
+      HBaseTableScans,
+      DataSink,
       BasicOperators,
       CartesianProduct,
       BroadcastNestedLoopJoin


### PR DESCRIPTION
This PR clean up HBaseSQLContext and HBaseStrategies to make them follow the SparkSQL convention. 
1. Implemented some TODO tags in HBaseSQLContext
2. HBaseStrategies now looks more like HiveStrategies, readers can understand it more easily if familiar with HiveStrategies
