### PR TITLE
bug report: CLI is not working after merge with upstream

### DIFF
--- a/bin/hbase-sql
+++ b/bin/hbase-sql
@@ -53,3 +53,5 @@ SUBMIT_USAGE_FUNCTION=usage
 gatherSparkSubmitOpts "$@"
 
 exec "$FWDIR"/bin/spark-submit --class $CLASS "${SUBMISSION_OPTS[@]}" spark-internal "${APPLICATION_OPTS[@]}"
+
+


### PR DESCRIPTION
CLI is not working after merging with latest spark code upstream

JackydeMacBook-Pro:spark jackylee$ ./bin/hbase-sql 
java.lang.ClassNotFoundException: org.apache.spark.sql.hbase.HBaseSQLCLIDriver
	at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:270)
	at org.apache.spark.deploy.SparkSubmit$.launch(SparkSubmit.scala:344)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:75)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties

